### PR TITLE
Add indexing job solution to documentation

### DIFF
--- a/Addon.Episerver.EnvironmentSynchronizer.sln
+++ b/Addon.Episerver.EnvironmentSynchronizer.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{886607B0-4954-4DED-962B-0B2BC85CAE15}"
 	ProjectSection(SolutionItems) = preProject
 		documentation\ForceLogin.md = documentation\ForceLogin.md
+		documentation\SearchReindexSynchronizer.md = documentation\SearchReindexSynchronizer.md
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Addon.Episerver.EnvironmentSynchronizer/Synchronizers/ScheduledJobs/ScheduledJobSynchronizer.cs
+++ b/Addon.Episerver.EnvironmentSynchronizer/Synchronizers/ScheduledJobs/ScheduledJobSynchronizer.cs
@@ -102,7 +102,7 @@ namespace Addon.Episerver.EnvironmentSynchronizer.Synchronizers.ScheduledJobs
             catch (Exception ex)
             {
                 extraInfoMessage = $"id=\"{job.Id}\" name=\"{job.Name}\"";
-                Logger.Error($"Error when try to loaf schedulejob id=\"{job.Id}\" name=\"{job.Name}\".", ex);
+                Logger.Error($"Error when try to load schedulejob id=\"{job.Id}\" name=\"{job.Name}\".", ex);
             }
 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example .json
     ],
     "ScheduledJobs": [
       {
-        "name": "*",
+        "Id": "*",
         "IsEnabled": false
       },
       {
@@ -197,7 +197,7 @@ This function is implemented for these projects that don´t want the payload of 
 **Id** is the GUID that identify the site. If this is provided it will ignore the "Name" attribute.  
 **Name** is the name of the sitedefinition that will be updated. If **Id** is not specified it will match the existing SiteDefinition in the Episerver CMS against this name.  
 **SiteUrl*** is the SiteUrl that this site should have/use.
-[**ForceLogin***](/Documentation/ForceLogin.md) will remove 'Everyone' AccessLevel.Read if it is found for the site.
+[**ForceLogin***](/documentation/ForceLogin.md) will remove 'Everyone' AccessLevel.Read if it is found for the site.
 
 ### hosts
 You need to specify all the hosts that the site needs. When the synchronizer is updating a SiteDefinition it will expect that you have specified all hostnames. So of you in Episerver CMS has a extra host that is not specified in the web.config it will be removed.
@@ -340,3 +340,6 @@ After the schronization is done. Click on the "History" tab and see the result.
 ## Run ScheduleJob
 If you run the scheduled job "Environment Synchronization" and get the message "Unable to resolve service for type 'Addon.Episerver.EnvironmentSynchronizer.IEnvironmentSynchronizationManager' while attempting to activate 'Addon.Episerver.EnvironmentSynchronizer.Jobs.EnvironmentSynchronizationJob'.". 
 Then you have installed the NuGet package but you have not add "services.AddEnvironmentSynchronization();" in the startup. Go through the installation instructions earlier in this readme.
+## Unable to autorun search and navigation indexing job
+Environment synchronizer is unable to trigger this job using `"AutoRun: true"`. This is because the job requires access to `HttpContext` and the `IScheduledJobExecutor` runs jobs as background tasks, where `HttpContext` does not exist.
+This can be solved by modifying the job via a custom synchronizer. [**See solution.**](/documentation/SearchReindexSynchronizer.md)

--- a/SearchReindexSynchronizer.md
+++ b/SearchReindexSynchronizer.md
@@ -1,0 +1,65 @@
+# Autorun search and navigation indexing job
+Environment synchronizer is unable to trigger this job using `"AutoRun: true"`. This is because the job requires access to `HttpContext`, and the `IScheduledJobExecutor` runs jobs as background tasks, where `HttpContext` does not exist.
+This can be solved by modifying the job via a custom synchronizer.
+
+[<= Back](../README.md)
+
+This extension method allows the job to be picked up by the scheduler and run later, removing the need to use `IScheduledJobExecutor`.
+
+```csharp
+using EPiServer.DataAbstraction;
+using System;
+
+namespace YourSite.Infrastructure.Extensions;
+
+public static class ScheduledJobExtensions
+{
+    public static void ScheduleRunNow(
+      this ScheduledJob job, IScheduledJobRepository scheduledJobRepository)
+    {
+        job.IntervalType = ScheduledIntervalType.None;
+        job.IntervalLength = 0;
+        job.IsEnabled = true;
+        job.NextExecution = DateTime.Now.AddSeconds(10);
+
+        scheduledJobRepository.Save(job);
+    }
+}
+```
+Now we can create a custom handler which schedules the job using our new extension method:
+```csharp
+using Addon.Episerver.EnvironmentSynchronizer;
+using YourSite.Infrastructure.Extensions;
+using EPiServer.DataAbstraction;
+using EPiServer.ServiceLocation;
+using System;
+
+namespace YourSite.Infrastructure.Envrionments;
+
+[ServiceConfiguration(typeof(IEnvironmentSynchronizer))]
+public class SearchReindexEnvironmentSynchronizer : IEnvironmentSynchronizer
+{
+    private readonly IScheduledJobRepository _scheduledJobRepository;
+    private readonly Guid _searchReindexJobId = new Guid("8eb257f9-ff22-40ec-9958-c1c5ba8c2a53");
+
+    public SearchReindexEnvironmentSynchronizer(IScheduledJobRepository scheduledJobRepository) => _scheduledJobRepository = scheduledJobRepository;
+
+    public string Synchronize(string environmentName)
+    {
+        if (EnvironmentHelper.IsPreProductionEnvironment(environmentName) || EnvironmentHelper.IsIntegrationEnvironment(environmentName))
+        {
+            var searchReindexJob = _scheduledJobRepository.Get(_searchReindexJobId);
+
+            if (searchReindexJob is not null)
+            {
+                searchReindexJob.ScheduleRunNow(_scheduledJobRepository);
+
+                return $"Scheduled search reindexing job.";
+            }
+        }
+
+        return string.Empty;
+    }
+}
+```
+Now you can be sure that the search index is updated every time the database is copied to your test environments from production.


### PR DESCRIPTION
# Autorun search and navigation indexing job
Environment synchronizer is unable to trigger this job using `"AutoRun: true"`. This is because the job requires access to `HttpContext`, and the `IScheduledJobExecutor` runs jobs as background tasks, where `HttpContext` does not exist.
This can be solved by modifying the job via a custom synchronizer.