### PR TITLE
Change to correct variable name

### DIFF
--- a/Addon.Episerver.EnvironmentSynchronizer/EnvironmentHelper.cs
+++ b/Addon.Episerver.EnvironmentSynchronizer/EnvironmentHelper.cs
@@ -9,7 +9,7 @@ namespace Addon.Episerver.EnvironmentSynchronizer
 
         public static bool IsPreProductionEnvironment(string environmentName)
         {
-            return string.Equals(environmentName, KnownEnvironmentNames.PreProduction);
+            return string.Equals(environmentName, KnownEnvironmentNames.Preproduction);
         }
 
         public static bool IsIntegrationEnvironment(string environmentName)

--- a/Addon.Episerver.EnvironmentSynchronizer/EnvironmentNames.cs
+++ b/Addon.Episerver.EnvironmentSynchronizer/EnvironmentNames.cs
@@ -3,7 +3,7 @@ namespace Addon.Episerver.EnvironmentSynchronizer
     public static class KnownEnvironmentNames
     {
         public const string Production = "Production";
-        public const string PreProduction = "PreProduction";
+        public const string Preproduction = "Preproduction";
         public const string Integration = "Integration";
     }
 }


### PR DESCRIPTION
The correct variable name for DXP solutions is "Preproduction", not "PreProduction".